### PR TITLE
Correct version number

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-nemo-gst-interfaces (1.0-1) unstable; urgency=medium
+nemo-gst-interfaces (0.20150126.0-1) unstable; urgency=medium
 
   * Initial release (Closes: #nnnn)  <nnnn is the bug number of your ITP>
 


### PR DESCRIPTION
I'm not completely sure here, but it seems like all the sailfishOS gstreamer repositories have tags like this, which we could use.

The same change should / could be done for the other packages as well